### PR TITLE
fix: paragraph spacing in list items

### DIFF
--- a/apps/web/src/components/tiptap-node/list-node/list-node.scss
+++ b/apps/web/src/components/tiptap-node/list-node/list-node.scss
@@ -47,6 +47,10 @@
       margin-top: 0;
       line-height: 1.6;
     }
+
+    p:not(:first-child) {
+      margin-top: 0;
+    }
   }
 
   // Ordered lists


### PR DESCRIPTION
Fixes ueberdosis/tiptap#8039.

A paragraph dropped into a list item keeps its 20px top margin because the global `p:not(:first-child)` rule overrides `li p`. Added a higher-specificity rule to keep the margin at 0.